### PR TITLE
[UI] プロフィールアイコンを線の細い新デザインに差し替え

### DIFF
--- a/src/components/Icon.astro
+++ b/src/components/Icon.astro
@@ -73,10 +73,10 @@ const newIcons = {
     </svg>
   `,
     'profile': `
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="\${className}">
-      <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v1a1 1 0 001 1h14a1 1 0 001-1v-1c0-2.66-5.33-4-8-4z" />
-    </svg>
-  `,
+   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="${className}">
+     <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
+   </svg>
+ `,
 };
 
 // 2つのアイコンオブジェクトを1つに合体させる


### PR DESCRIPTION
## 概要
フッターに表示されるプロフィールアイコンを、Stitch のデザインに基づいた新しい SVG アイコンに差し替えました。

## 関連 Issue
Close #6